### PR TITLE
Improve `[Validate]` codefixer behavior

### DIFF
--- a/src/Immediate.Validations.CodeFixes/AddValidateAttributeCodefixProvider.cs
+++ b/src/Immediate.Validations.CodeFixes/AddValidateAttributeCodefixProvider.cs
@@ -3,7 +3,10 @@ using Immediate.Validations.Analyzers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Simplification;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Immediate.Validations.CodeFixes;
@@ -30,26 +33,44 @@ public sealed class AddValidateAttributeCodefixProvider : CodeFixProvider
 		context.RegisterCodeFix(
 			CodeAction.Create(
 				"Add `[Validate]`",
-				createChangedDocument: _ =>
-					AddValidateAttribute(context.Document, root, typeDeclaration),
+				createChangedDocument: token =>
+					AddValidateAttribute(context.Document, root, typeDeclaration, token),
 				equivalenceKey: nameof(AddValidateAttributeCodefixProvider)
 			),
 			diagnostic
 		);
 	}
 
-	private static Task<Document> AddValidateAttribute(Document document, CompilationUnitSyntax root, TypeDeclarationSyntax typeDeclaration)
+	private static async Task<Document> AddValidateAttribute(Document document, CompilationUnitSyntax root, TypeDeclarationSyntax typeDeclaration, CancellationToken token)
 	{
+		var model = await document.GetSemanticModelAsync(token);
+
+		var validateSymbol = model?.Compilation
+			.GetTypeByMetadataName("Immediate.Validations.Shared.ValidateAttribute")!;
+
+		var referenceId = DocumentationCommentId.CreateReferenceId(validateSymbol);
+		var annotation = new SyntaxAnnotation("SymbolId", referenceId);
+
 		var newDecl = typeDeclaration
+			.WithoutLeadingTrivia()
 			.WithAttributeLists(
 				typeDeclaration.AttributeLists
-					.Add(AttributeList(
-						SingletonSeparatedList(
-							Attribute(
-								IdentifierName("Validate"))))));
+					.Add(
+						AttributeList(
+							SingletonSeparatedList(
+								Attribute(
+									IdentifierName("Validate")
+								)
+							)
+						)
+							.WithLeadingTrivia(typeDeclaration.GetLeadingTrivia())
+							.WithTrailingTrivia(ElasticCarriageReturnLineFeed)
+					)
+			)
+			.WithAdditionalAnnotations(Simplifier.AddImportsAnnotation, annotation)
+			.WithAdditionalAnnotations(Formatter.Annotation);
 
 		var newRoot = root.ReplaceNode(typeDeclaration, newDecl);
-		var newDocument = document.WithSyntaxRoot(newRoot);
-		return Task.FromResult(newDocument);
+		return document.WithSyntaxRoot(newRoot);
 	}
 }

--- a/src/Immediate.Validations.CodeFixes/AddValidateAttributeCodefixProvider.cs
+++ b/src/Immediate.Validations.CodeFixes/AddValidateAttributeCodefixProvider.cs
@@ -64,6 +64,7 @@ public sealed class AddValidateAttributeCodefixProvider : CodeFixProvider
 				)
 			)
 		)
+			.WithAdditionalAnnotations(Simplifier.AddImportsAnnotation, annotation)
 			.WithTrailingTrivia(newLineSyntax);
 
 		var newDecl = typeDeclaration.AttributeLists switch
@@ -73,22 +74,27 @@ public sealed class AddValidateAttributeCodefixProvider : CodeFixProvider
 					.WithoutLeadingTrivia()
 					.WithAttributeLists(
 						typeDeclaration.AttributeLists
-							.Add(validateAttribute.WithLeadingTrivia(typeDeclaration.GetLeadingTrivia()))
+							.Add(
+								validateAttribute
+									.WithLeadingTrivia(typeDeclaration.GetLeadingTrivia())
+									.WithAdditionalAnnotations(Formatter.Annotation)
+							)
 					),
 
 			_ =>
 				typeDeclaration
 					.WithAttributeLists(
 						typeDeclaration.AttributeLists
-							.Add(validateAttribute)
+							.Add(
+								validateAttribute
+									.WithAdditionalAnnotations(Formatter.Annotation)
+							)
 					),
 		};
 
 		var newRoot = root.ReplaceNode(
 			typeDeclaration,
 			newDecl
-				.WithAdditionalAnnotations(Simplifier.AddImportsAnnotation, annotation)
-				.WithAdditionalAnnotations(Formatter.Annotation)
 		);
 
 		return document.WithSyntaxRoot(newRoot);

--- a/src/Immediate.Validations.CodeFixes/AddValidateAttributeCodefixProvider.cs
+++ b/src/Immediate.Validations.CodeFixes/AddValidateAttributeCodefixProvider.cs
@@ -3,7 +3,6 @@ using Immediate.Validations.Analyzers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Simplification;
@@ -51,24 +50,36 @@ public sealed class AddValidateAttributeCodefixProvider : CodeFixProvider
 		var referenceId = DocumentationCommentId.CreateReferenceId(validateSymbol);
 		var annotation = new SyntaxAnnotation("SymbolId", referenceId);
 
-		var newDecl = typeDeclaration
-			.WithoutLeadingTrivia()
-			.WithAttributeLists(
-				typeDeclaration.AttributeLists
-					.Add(
-						AttributeList(
-							SingletonSeparatedList(
-								Attribute(
-									IdentifierName("Validate")
-								)
-							)
-						)
-							.WithLeadingTrivia(typeDeclaration.GetLeadingTrivia())
-							.WithTrailingTrivia(ElasticCarriageReturnLineFeed)
-					)
+		var validateAttribute = AttributeList(
+			SingletonSeparatedList(
+				Attribute(
+					IdentifierName("Validate")
+				)
 			)
-			.WithAdditionalAnnotations(Simplifier.AddImportsAnnotation, annotation)
-			.WithAdditionalAnnotations(Formatter.Annotation);
+		)
+			.WithTrailingTrivia(ElasticCarriageReturnLineFeed);
+
+		var newDecl = typeDeclaration.AttributeLists switch
+		{
+			[] =>
+				typeDeclaration
+					.WithoutLeadingTrivia()
+					.WithAttributeLists(
+						typeDeclaration.AttributeLists
+							.Add(validateAttribute.WithLeadingTrivia(typeDeclaration.GetLeadingTrivia()))
+					)
+					.WithAdditionalAnnotations(Simplifier.AddImportsAnnotation, annotation)
+					.WithAdditionalAnnotations(Formatter.Annotation),
+
+			_ =>
+				typeDeclaration
+					.WithAttributeLists(
+						typeDeclaration.AttributeLists
+							.Add(validateAttribute.WithLeadingTrivia(ElasticCarriageReturnLineFeed))
+					)
+					.WithAdditionalAnnotations(Simplifier.AddImportsAnnotation, annotation)
+					.WithAdditionalAnnotations(Formatter.Annotation),
+		};
 
 		var newRoot = root.ReplaceNode(typeDeclaration, newDecl);
 		return document.WithSyntaxRoot(newRoot);

--- a/src/Immediate.Validations.CodeFixes/AddValidateAttributeCodefixProvider.cs
+++ b/src/Immediate.Validations.CodeFixes/AddValidateAttributeCodefixProvider.cs
@@ -3,6 +3,7 @@ using Immediate.Validations.Analyzers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Simplification;
@@ -50,6 +51,12 @@ public sealed class AddValidateAttributeCodefixProvider : CodeFixProvider
 		var referenceId = DocumentationCommentId.CreateReferenceId(validateSymbol);
 		var annotation = new SyntaxAnnotation("SymbolId", referenceId);
 
+		var newLineSyntax = typeDeclaration.DescendantTrivia()
+			.FirstOrDefault(t => t.IsKind(SyntaxKind.EndOfLineTrivia));
+
+		if (newLineSyntax == default)
+			newLineSyntax = ElasticLineFeed;
+
 		var validateAttribute = AttributeList(
 			SingletonSeparatedList(
 				Attribute(
@@ -57,7 +64,7 @@ public sealed class AddValidateAttributeCodefixProvider : CodeFixProvider
 				)
 			)
 		)
-			.WithTrailingTrivia(ElasticCarriageReturnLineFeed);
+			.WithTrailingTrivia(newLineSyntax);
 
 		var newDecl = typeDeclaration.AttributeLists switch
 		{
@@ -67,21 +74,23 @@ public sealed class AddValidateAttributeCodefixProvider : CodeFixProvider
 					.WithAttributeLists(
 						typeDeclaration.AttributeLists
 							.Add(validateAttribute.WithLeadingTrivia(typeDeclaration.GetLeadingTrivia()))
-					)
-					.WithAdditionalAnnotations(Simplifier.AddImportsAnnotation, annotation)
-					.WithAdditionalAnnotations(Formatter.Annotation),
+					),
 
 			_ =>
 				typeDeclaration
 					.WithAttributeLists(
 						typeDeclaration.AttributeLists
-							.Add(validateAttribute.WithLeadingTrivia(ElasticCarriageReturnLineFeed))
-					)
-					.WithAdditionalAnnotations(Simplifier.AddImportsAnnotation, annotation)
-					.WithAdditionalAnnotations(Formatter.Annotation),
+							.Add(validateAttribute)
+					),
 		};
 
-		var newRoot = root.ReplaceNode(typeDeclaration, newDecl);
+		var newRoot = root.ReplaceNode(
+			typeDeclaration,
+			newDecl
+				.WithAdditionalAnnotations(Simplifier.AddImportsAnnotation, annotation)
+				.WithAdditionalAnnotations(Formatter.Annotation)
+		);
+
 		return document.WithSyntaxRoot(newRoot);
 	}
 }

--- a/tests/Immediate.Validations.Tests/CodeFixTests/AddValidateAttributeCodefixProviderTests.cs
+++ b/tests/Immediate.Validations.Tests/CodeFixTests/AddValidateAttributeCodefixProviderTests.cs
@@ -34,6 +34,46 @@ public sealed class AddValidateAttributeCodefixProviderTests
 		).RunAsync(TestContext.Current.CancellationToken);
 
 	[Fact]
+	public async Task AddValidateAttributeWorksCorrectlyWithOtherAttributes() =>
+		await CodeFixTestHelper.CreateCodeFixTest<ValidateClassAnalyzer, AddValidateAttributeCodefixProvider>(
+			"""
+			using System;
+
+			namespace Immediate.Validations.Shared;
+
+			[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface)]
+			public sealed class MyStuffAttribute : Attribute;
+			
+			[MyStuff]
+			public sealed record {|IV0012:Data|} : IValidationTarget<Data>
+			{
+				public ValidationResult Validate() => [];
+				public ValidationResult Validate(ValidationResult errors) => [];
+				public static ValidationResult Validate(Data target) => [];
+				public static ValidationResult Validate(Data target, ValidationResult errors) => [];
+			}
+			""",
+			"""
+			using System;
+			
+			namespace Immediate.Validations.Shared;
+			
+			[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface)]
+			public sealed class MyStuffAttribute : Attribute;
+			
+			[MyStuff]
+			[Validate]
+			public sealed record {|IV0012:Data|} : IValidationTarget<Data>
+			{
+				public ValidationResult Validate() => [];
+				public ValidationResult Validate(ValidationResult errors) => [];
+				public static ValidationResult Validate(Data target) => [];
+				public static ValidationResult Validate(Data target, ValidationResult errors) => [];
+			}
+			"""
+		).RunAsync(TestContext.Current.CancellationToken);
+
+	[Fact]
 	public async Task AddValidateAttributeWorksCorrectlyWithXmlDocs() =>
 		await CodeFixTestHelper.CreateCodeFixTest<ValidateClassAnalyzer, AddValidateAttributeCodefixProvider>(
 			"""
@@ -54,6 +94,48 @@ public sealed class AddValidateAttributeCodefixProviderTests
 			/// <summary>documentation</summary>
 			[Validate]
 			public sealed record Data : IValidationTarget<Data>
+			{
+				public ValidationResult Validate() => [];
+				public ValidationResult Validate(ValidationResult errors) => [];
+				public static ValidationResult Validate(Data target) => [];
+				public static ValidationResult Validate(Data target, ValidationResult errors) => [];
+			}
+			"""
+		).RunAsync(TestContext.Current.CancellationToken);
+
+	[Fact]
+	public async Task AddValidateAttributeWorksCorrectlyWithXmlDocsAndOtherAttributes() =>
+		await CodeFixTestHelper.CreateCodeFixTest<ValidateClassAnalyzer, AddValidateAttributeCodefixProvider>(
+			"""
+			using System;
+
+			namespace Immediate.Validations.Shared;
+
+			[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface)]
+			public sealed class MyStuffAttribute : Attribute;
+			
+			/// <summary>documentation</summary>
+			[MyStuff]
+			public sealed record {|IV0012:Data|} : IValidationTarget<Data>
+			{
+				public ValidationResult Validate() => [];
+				public ValidationResult Validate(ValidationResult errors) => [];
+				public static ValidationResult Validate(Data target) => [];
+				public static ValidationResult Validate(Data target, ValidationResult errors) => [];
+			}
+			""",
+			"""
+			using System;
+			
+			namespace Immediate.Validations.Shared;
+			
+			[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface)]
+			public sealed class MyStuffAttribute : Attribute;
+			
+			/// <summary>documentation</summary>
+			[MyStuff]
+			[Validate]
+			public sealed record {|IV0012:Data|} : IValidationTarget<Data>
 			{
 				public ValidationResult Validate() => [];
 				public ValidationResult Validate(ValidationResult errors) => [];

--- a/tests/Immediate.Validations.Tests/CodeFixTests/AddValidateAttributeCodefixProviderTests.cs
+++ b/tests/Immediate.Validations.Tests/CodeFixTests/AddValidateAttributeCodefixProviderTests.cs
@@ -32,4 +32,34 @@ public sealed class AddValidateAttributeCodefixProviderTests
 			}
 			"""
 		).RunAsync(TestContext.Current.CancellationToken);
+
+	[Fact]
+	public async Task AddValidateAttributeWorksCorrectlyWithXmlDocs() =>
+		await CodeFixTestHelper.CreateCodeFixTest<ValidateClassAnalyzer, AddValidateAttributeCodefixProvider>(
+			"""
+			namespace Immediate.Validations.Shared;
+			
+			/// <summary>documentation</summary>
+			public sealed record {|IV0012:Data|} : IValidationTarget<Data>
+			{
+				public ValidationResult Validate() => [];
+				public ValidationResult Validate(ValidationResult errors) => [];
+				public static ValidationResult Validate(Data target) => [];
+				public static ValidationResult Validate(Data target, ValidationResult errors) => [];
+			}
+			""",
+			"""
+			namespace Immediate.Validations.Shared;
+			
+			/// <summary>documentation</summary>
+			[Validate]
+			public sealed record Data : IValidationTarget<Data>
+			{
+				public ValidationResult Validate() => [];
+				public ValidationResult Validate(ValidationResult errors) => [];
+				public static ValidationResult Validate(Data target) => [];
+				public static ValidationResult Validate(Data target, ValidationResult errors) => [];
+			}
+			"""
+		).RunAsync(TestContext.Current.CancellationToken);
 }

--- a/tests/Immediate.Validations.Tests/CodeFixTests/AddValidateAttributeCodefixProviderTests.cs
+++ b/tests/Immediate.Validations.Tests/CodeFixTests/AddValidateAttributeCodefixProviderTests.cs
@@ -9,26 +9,28 @@ public sealed class AddValidateAttributeCodefixProviderTests
 	public async Task AddValidateAttribute() =>
 		await CodeFixTestHelper.CreateCodeFixTest<ValidateClassAnalyzer, AddValidateAttributeCodefixProvider>(
 			"""
-			namespace Immediate.Validations.Shared;
+			namespace Immediate.Validations.Testing;
 			
-			public sealed record {|IV0012:Data|} : IValidationTarget<Data>
+			public sealed record {|IV0012:Data|} : Immediate.Validations.Shared.IValidationTarget<Data>
 			{
-				public ValidationResult Validate() => [];
-				public ValidationResult Validate(ValidationResult errors) => [];
-				public static ValidationResult Validate(Data target) => [];
-				public static ValidationResult Validate(Data target, ValidationResult errors) => [];
+				public Immediate.Validations.Shared.ValidationResult Validate() => [];
+				public Immediate.Validations.Shared.ValidationResult Validate(Immediate.Validations.Shared.ValidationResult errors) => [];
+				public static Immediate.Validations.Shared.ValidationResult Validate(Data target) => [];
+				public static Immediate.Validations.Shared.ValidationResult Validate(Data target, Immediate.Validations.Shared.ValidationResult errors) => [];
 			}
 			""",
 			"""
-			namespace Immediate.Validations.Shared;
+			using Immediate.Validations.Shared;
+
+			namespace Immediate.Validations.Testing;
 			
 			[Validate]
-			public sealed record Data : IValidationTarget<Data>
+			public sealed record Data : Immediate.Validations.Shared.IValidationTarget<Data>
 			{
-				public ValidationResult Validate() => [];
-				public ValidationResult Validate(ValidationResult errors) => [];
-				public static ValidationResult Validate(Data target) => [];
-				public static ValidationResult Validate(Data target, ValidationResult errors) => [];
+				public Immediate.Validations.Shared.ValidationResult Validate() => [];
+				public Immediate.Validations.Shared.ValidationResult Validate(Immediate.Validations.Shared.ValidationResult errors) => [];
+				public static Immediate.Validations.Shared.ValidationResult Validate(Data target) => [];
+				public static Immediate.Validations.Shared.ValidationResult Validate(Data target, Immediate.Validations.Shared.ValidationResult errors) => [];
 			}
 			"""
 		).RunAsync(TestContext.Current.CancellationToken);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting and import handling when adding the `[Validate]` attribute.
  * Preserved XML documentation, existing attributes, and declaration formatting when applying the code fix.
  * Added cancellation support for more responsive code-fix operations.

* **Tests**
  * Added coverage for records with no attributes, existing attributes, XML documentation, and combined documentation and attributes.
  * Verified that `[Validate]` is inserted correctly without altering existing declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->