### PR TITLE
Properly Multi-target Roslyn

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
+      with:
+        fetch-depth: '0'
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
         dotnet-version: |
           11.0.x
 
+    - name: Restore tools
+      run: dotnet tool restore
+
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
@@ -39,6 +42,8 @@ jobs:
 
     - name: Package 
       run: dotnet pack -c Release --no-build --property:PackageOutputPath=../../nupkgs
+    - name: Validate Package 
+      run: dotnet tool run dotnet-validate -- package local ./nupkgs/*.nupkg
 
     - name: NuGet login (OIDC → temp API key)
       uses: NuGet/login@v1

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-	<TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
+	<TargetFrameworks>net8.0;net10.0;net11.0</TargetFrameworks>
 	<LangVersion>latest</LangVersion>
 
 	<Nullable>enable</Nullable>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,17 +26,9 @@
 	<PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="8.0.30" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-	<PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.11" />
-	<PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
-	<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.20" />
-	<PackageVersion Include="Microsoft.Extensions.Localization" Version="9.0.20" />
-	<PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="9.0.20" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
 	<PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.11" />
-	<PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.300" />
+	<PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.400" />
 	<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
 	<PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.11" />
 	<PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="10.0.11" />
@@ -51,25 +43,18 @@
   </ItemGroup>
 
   <!-- IV.Generators dependencies -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net11.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net11.0' or '$(TargetFramework)' == 'roslyn5.9' ">
 	<PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.9.0" />
 	<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
 	<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.9.0" />
 	<PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.9.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' or '$(TargetFramework)' == 'roslyn5.0' ">
 	<PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" />
 	<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
 	<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
 	<PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-	<PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.12.0" />
-	<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
-	<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
-	<PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.12.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
@@ -79,7 +64,7 @@
 	<PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.11.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'roslyn4.8' ">
 	<PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
 	<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
 	<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />

--- a/src/Immediate.Validations.Analyzers/Immediate.Validations.Analyzers.csproj
+++ b/src/Immediate.Validations.Analyzers/Immediate.Validations.Analyzers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
+	<TargetFrameworks>roslyn4.8;roslyn5.0;roslyn5.9</TargetFrameworks>
 	<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 	<IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>
@@ -14,5 +14,23 @@
 	<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="All" />
 	<PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'roslyn4.8' ">
+	<TargetFrameworkIdentifier>.NETStandard</TargetFrameworkIdentifier>
+	<TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+	<TargetFrameworkMoniker>.NETStandard,Version=v2.0</TargetFrameworkMoniker>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'roslyn5.0' ">
+	<TargetFrameworkIdentifier>.NETStandard</TargetFrameworkIdentifier>
+	<TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+	<TargetFrameworkMoniker>.NETStandard,Version=v2.0</TargetFrameworkMoniker>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'roslyn5.9' ">
+	<TargetFrameworkIdentifier>.NETStandard</TargetFrameworkIdentifier>
+	<TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+	<TargetFrameworkMoniker>.NETStandard,Version=v2.0</TargetFrameworkMoniker>
+  </PropertyGroup>
 
 </Project>

--- a/src/Immediate.Validations.CodeFixes/Immediate.Validations.CodeFixes.csproj
+++ b/src/Immediate.Validations.CodeFixes/Immediate.Validations.CodeFixes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>netstandard2.0</TargetFrameworks>
+	<TargetFrameworks>roslyn4.8;roslyn5.0;roslyn5.9</TargetFrameworks>
 	<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 	<IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>
@@ -16,5 +16,23 @@
 	<PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
 	<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" />
   </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'roslyn4.8' ">
+	<TargetFrameworkIdentifier>.NETStandard</TargetFrameworkIdentifier>
+	<TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+	<TargetFrameworkMoniker>.NETStandard,Version=v2.0</TargetFrameworkMoniker>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'roslyn5.0' ">
+	<TargetFrameworkIdentifier>.NETStandard</TargetFrameworkIdentifier>
+	<TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+	<TargetFrameworkMoniker>.NETStandard,Version=v2.0</TargetFrameworkMoniker>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'roslyn5.9' ">
+	<TargetFrameworkIdentifier>.NETStandard</TargetFrameworkIdentifier>
+	<TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+	<TargetFrameworkMoniker>.NETStandard,Version=v2.0</TargetFrameworkMoniker>
+  </PropertyGroup>
 
 </Project>

--- a/src/Immediate.Validations.Generators/Immediate.Validations.Generators.csproj
+++ b/src/Immediate.Validations.Generators/Immediate.Validations.Generators.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
+	<TargetFrameworks>roslyn4.8;roslyn5.0;roslyn5.9</TargetFrameworks>
 	<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 	<IsRoslynComponent>true</IsRoslynComponent>
+	<NoWarn>$(NoWarn);CA1716</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,17 +20,48 @@
 	<PackageReference Include="AssemblyMetadata.Generators" PrivateAssets="All" />
 	<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
 	<PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+  </ItemGroup>
+
+  <!-- Scriban (code in netstandard2.0; lib in net10+) -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'roslyn4.8' ">
+	<PackageReference Include="Scriban" PrivateAssets="all" IncludeAssets="Build" />
+  </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'roslyn4.8' ">
+	<PackageScribanIncludeSource>true</PackageScribanIncludeSource>
+	<DefineConstants>$(DefineConstants);SCRIBAN_NO_ASYNC</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'roslyn4.8' ">
 	<PackageReference Include="Scriban" PrivateAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'roslyn4.8' ">
 	<GetTargetPathDependsOn>$(GetTargetPathDependsOn);GetDependencyTargetPaths</GetTargetPathDependsOn>
   </PropertyGroup>
 
-  <Target Name="GetDependencyTargetPaths">
+  <Target Name="GetDependencyTargetPaths" Condition=" '$(TargetFramework)' != 'roslyn4.8' ">
 	<ItemGroup>
 	  <TargetPathWithTargetPlatformMoniker Include="$(PkgScriban)/lib/netstandard2.0/Scriban.dll" IncludeRuntimeDependency="false" />
 	</ItemGroup>
   </Target>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'roslyn4.8' ">
+	<TargetFrameworkIdentifier>.NETStandard</TargetFrameworkIdentifier>
+	<TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+	<TargetFrameworkMoniker>.NETStandard,Version=v2.0</TargetFrameworkMoniker>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'roslyn5.0' ">
+	<TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+	<TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
+	<TargetFrameworkMoniker>.NETCoreApp,Version=v10.0</TargetFrameworkMoniker>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'roslyn5.9' ">
+	<TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+	<TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
+	<TargetFrameworkMoniker>.NETCoreApp,Version=v10.0</TargetFrameworkMoniker>
+  </PropertyGroup>
 
 </Project>

--- a/src/Immediate.Validations.Shared/Immediate.Validations.Shared.csproj
+++ b/src/Immediate.Validations.Shared/Immediate.Validations.Shared.csproj
@@ -1,17 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="../Immediate.Validations.Analyzers/Immediate.Validations.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="../Immediate.Validations.CodeFixes/Immediate.Validations.CodeFixes.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Immediate.Handlers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Immediate.Validations.FunctionalTests" />
+  </ItemGroup>
+
+  <PropertyGroup>
+	<RoslynVersion Condition=" '$(TargetFramework)' == 'net8.0' ">roslyn4.8</RoslynVersion>
+	<RoslynVersion Condition=" '$(TargetFramework)' == 'net10.0' ">roslyn5.0</RoslynVersion>
+	<RoslynVersion Condition=" '$(TargetFramework)' == 'net11.0' ">roslyn5.9</RoslynVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+	<ProjectReference Include="../../src/Immediate.Validations.Analyzers/Immediate.Validations.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false">
+	  <SetTargetFramework>TargetFramework=$(RoslynVersion)</SetTargetFramework>
+	</ProjectReference>
+
+	<ProjectReference Include="../../src/Immediate.Validations.CodeFixes/Immediate.Validations.CodeFixes.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false">
+	  <SetTargetFramework>TargetFramework=$(RoslynVersion)</SetTargetFramework>
+	</ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/src/Immediate.Validations/CompatibilitySuppressions.xml
+++ b/src/Immediate.Validations/CompatibilitySuppressions.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:System.Runtime.CompilerServices.IsExternalInit</Target>
+    <Left>lib/net10.0/Immediate.Validations.Shared.dll</Left>
+    <Right>lib/net10.0/Immediate.Validations.Shared.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:System.Runtime.CompilerServices.RequiresLocationAttribute</Target>
+    <Left>lib/net10.0/Immediate.Validations.Shared.dll</Left>
+    <Right>lib/net10.0/Immediate.Validations.Shared.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:System.Runtime.CompilerServices.IsExternalInit</Target>
+    <Left>lib/net8.0/Immediate.Validations.Shared.dll</Left>
+    <Right>lib/net8.0/Immediate.Validations.Shared.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:System.Runtime.CompilerServices.RequiresLocationAttribute</Target>
+    <Left>lib/net8.0/Immediate.Validations.Shared.dll</Left>
+    <Right>lib/net8.0/Immediate.Validations.Shared.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:System.Runtime.CompilerServices.IsExternalInit</Target>
+    <Left>lib/net9.0/Immediate.Validations.Shared.dll</Left>
+    <Right>lib/net8.0/Immediate.Validations.Shared.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:System.Runtime.CompilerServices.RequiresLocationAttribute</Target>
+    <Left>lib/net9.0/Immediate.Validations.Shared.dll</Left>
+    <Right>lib/net8.0/Immediate.Validations.Shared.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/src/Immediate.Validations/Immediate.Validations.csproj
+++ b/src/Immediate.Validations/Immediate.Validations.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
 	<IsPackable>true</IsPackable>
 	<IncludeBuildOutput>false</IncludeBuildOutput>
+
+	<EnablePackageValidation>true</EnablePackageValidation>
+	<PackageValidationBaselineVersion>3.0.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Nuget">
@@ -22,7 +25,7 @@
 
   <ItemGroup>
 	<PackageReference Include="Immediate.Handlers" />
-	<PackageReference Include="Microsoft.Extensions.Localization.Abstractions" NoWarn="NU5104" />
+	<PackageReference Include="Microsoft.Extensions.Localization.Abstractions" />
   </ItemGroup>
 
   <!--
@@ -43,46 +46,67 @@
 	  PackagePath="lib/$(TargetFramework)" />
   </ItemGroup>
 
-  <!-- roslyn 4.8 for net8/net9 -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-	<TfmSpecificPackageFile
-	  Include="../Immediate.Validations.Analyzers/bin/$(Configuration)/netstandard2.0/Immediate.Validations.Analyzers.dll"
+  <ItemGroup>
+	<None
+	  Include="../Immediate.Validations.Analyzers/bin/$(Configuration)/roslyn4.8/Immediate.Validations.Analyzers.dll"
 	  Pack="true"
 	  PackagePath="analyzers/dotnet/roslyn4.8/cs" />
 
-	<TfmSpecificPackageFile
-	  Include="../Immediate.Validations.CodeFixes/bin/$(Configuration)/netstandard2.0/Immediate.Validations.CodeFixes.dll"
+	<None
+	  Include="../Immediate.Validations.CodeFixes/bin/$(Configuration)/roslyn4.8/Immediate.Validations.CodeFixes.dll"
 	  Pack="true"
 	  PackagePath="analyzers/dotnet/roslyn4.8/cs" />
 
-	<TfmSpecificPackageFile
-	  Include="../Immediate.Validations.Generators/bin/$(Configuration)/netstandard2.0/Immediate.Validations.Generators.dll"
+	<None
+	  Include="../Immediate.Validations.Generators/bin/$(Configuration)/roslyn4.8/Immediate.Validations.Generators.dll"
 	  Pack="true"
 	  PackagePath="analyzers/dotnet/roslyn4.8/cs" />
   </ItemGroup>
 
-  <!-- roslyn 5.0 for net10/net11 -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-	<TfmSpecificPackageFile
-	  Include="../Immediate.Validations.Analyzers/bin/$(Configuration)/net10.0/Immediate.Validations.Analyzers.dll"
+  <ItemGroup>
+	<None
+	  Include="../Immediate.Validations.Analyzers/bin/$(Configuration)/roslyn5.0/Immediate.Validations.Analyzers.dll"
 	  Pack="true"
 	  PackagePath="analyzers/dotnet/roslyn5.0/cs" />
 
-	<!-- Specifically use ns2.0 for VS -->
-	<TfmSpecificPackageFile
-	  Include="../Immediate.Validations.CodeFixes/bin/$(Configuration)/netstandard2.0/Immediate.Validations.CodeFixes.dll"
+	<None
+	  Include="../Immediate.Validations.CodeFixes/bin/$(Configuration)/roslyn5.0/Immediate.Validations.CodeFixes.dll"
+	  Pack="true"
+	  PackagePath="analyzers/dotnet/roslyn5.0/cs" />
+
+	<None
+	  Include="../Immediate.Validations.Generators/bin/$(Configuration)/roslyn5.0/Immediate.Validations.Generators.dll"
 	  Pack="true"
 	  PackagePath="analyzers/dotnet/roslyn5.0/cs" />
 
 	<TfmSpecificPackageFile
-	  Include="../Immediate.Validations.Generators/bin/$(Configuration)/net10.0/Immediate.Validations.Generators.dll"
-	  Pack="true"
-	  PackagePath="analyzers/dotnet/roslyn5.0/cs" />
-
-	<TfmSpecificPackageFile
+	  Condition=" '$(TargetFramework)' == 'net8.0' "
 	  Include="$(PkgScriban)/lib/net8.0/Scriban.dll"
 	  Pack="true"
 	  PackagePath="analyzers/dotnet/roslyn5.0/cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+	<None
+	  Include="../Immediate.Validations.Analyzers/bin/$(Configuration)/roslyn5.9/Immediate.Validations.Analyzers.dll"
+	  Pack="true"
+	  PackagePath="analyzers/dotnet/roslyn5.9/cs" />
+
+	<None
+	  Include="../Immediate.Validations.CodeFixes/bin/$(Configuration)/roslyn5.9/Immediate.Validations.CodeFixes.dll"
+	  Pack="true"
+	  PackagePath="analyzers/dotnet/roslyn5.9/cs" />
+
+	<None
+	  Include="../Immediate.Validations.Generators/bin/$(Configuration)/roslyn5.9/Immediate.Validations.Generators.dll"
+	  Pack="true"
+	  PackagePath="analyzers/dotnet/roslyn5.9/cs" />
+
+	<TfmSpecificPackageFile
+	  Condition=" '$(TargetFramework)' == 'net8.0' "
+	  Include="$(PkgScriban)/lib/net8.0/Scriban.dll"
+	  Pack="true"
+	  PackagePath="analyzers/dotnet/roslyn5.9/cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -90,10 +114,27 @@
   </ItemGroup>
 
   <ItemGroup>
-	<ProjectReference Include="../Immediate.Validations.Analyzers/Immediate.Validations.Analyzers.csproj" ReferenceOutputAssembly="false" />
-	<ProjectReference Include="../Immediate.Validations.CodeFixes/Immediate.Validations.CodeFixes.csproj" ReferenceOutputAssembly="false" />
-	<ProjectReference Include="../Immediate.Validations.Generators/Immediate.Validations.Generators.csproj" ReferenceOutputAssembly="false" />
 	<ProjectReference Include="../Immediate.Validations.Shared/Immediate.Validations.Shared.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <PropertyGroup>
+	<RoslynVersion Condition=" '$(TargetFramework)' == 'net8.0' ">roslyn4.8</RoslynVersion>
+	<RoslynVersion Condition=" '$(TargetFramework)' == 'net10.0' ">roslyn5.0</RoslynVersion>
+	<RoslynVersion Condition=" '$(TargetFramework)' == 'net11.0' ">roslyn5.9</RoslynVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+	<ProjectReference Include="../../src/Immediate.Validations.Analyzers/Immediate.Validations.Analyzers.csproj" ReferenceOutputAssembly="false">
+	  <SetTargetFramework>TargetFramework=$(RoslynVersion)</SetTargetFramework>
+	</ProjectReference>
+
+	<ProjectReference Include="../../src/Immediate.Validations.CodeFixes/Immediate.Validations.CodeFixes.csproj" ReferenceOutputAssembly="false">
+	  <SetTargetFramework>TargetFramework=$(RoslynVersion)</SetTargetFramework>
+	</ProjectReference>
+
+	<ProjectReference Include="../../src/Immediate.Validations.Generators/Immediate.Validations.Generators.csproj" ReferenceOutputAssembly="false">
+	  <SetTargetFramework>TargetFramework=$(RoslynVersion)</SetTargetFramework>
+	</ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/tests/Immediate.Validations.FunctionalTests/Immediate.Validations.FunctionalTests.csproj
+++ b/tests/Immediate.Validations.FunctionalTests/Immediate.Validations.FunctionalTests.csproj
@@ -10,13 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-	<ProjectReference Include="../../src/Immediate.Validations.Shared/Immediate.Validations.Shared.csproj" />
-	<ProjectReference Include="../../src/Immediate.Validations.Generators/Immediate.Validations.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-	<ProjectReference Include="../../src/Immediate.Validations.Analyzers/Immediate.Validations.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-	<ProjectReference Include="../../src/Immediate.Validations.CodeFixes/Immediate.Validations.CodeFixes.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-  </ItemGroup>
-
-  <ItemGroup>
 	<PackageReference Include="Immediate.Handlers" />
 	<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
 	<PackageReference Include="Microsoft.Extensions.Localization" />
@@ -25,27 +18,51 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Update="Resources\Validators.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Validators.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <EmbeddedResource Update="Resources\Validators.fr-CA.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Validators.fr-CA.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
+	<EmbeddedResource Update="Resources\Validators.resx">
+	  <Generator>ResXFileCodeGenerator</Generator>
+	  <LastGenOutput>Validators.Designer.cs</LastGenOutput>
+	</EmbeddedResource>
+	<EmbeddedResource Update="Resources\Validators.fr-CA.resx">
+	  <Generator>ResXFileCodeGenerator</Generator>
+	  <LastGenOutput>Validators.fr-CA.Designer.cs</LastGenOutput>
+	</EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Update="Resources\Validators.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Validators.resx</DependentUpon>
-    </Compile>
-    <Compile Update="Resources\Validators.fr-CA.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Validators.fr-CA.resx</DependentUpon>
-    </Compile>
+	<Compile Update="Resources\Validators.Designer.cs">
+	  <DesignTime>True</DesignTime>
+	  <AutoGen>True</AutoGen>
+	  <DependentUpon>Validators.resx</DependentUpon>
+	</Compile>
+	<Compile Update="Resources\Validators.fr-CA.Designer.cs">
+	  <DesignTime>True</DesignTime>
+	  <AutoGen>True</AutoGen>
+	  <DependentUpon>Validators.fr-CA.resx</DependentUpon>
+	</Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+	<ProjectReference Include="../../src/Immediate.Validations.Shared/Immediate.Validations.Shared.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+	<RoslynVersion Condition=" '$(TargetFramework)' == 'net8.0' ">roslyn4.8</RoslynVersion>
+	<RoslynVersion Condition=" '$(TargetFramework)' == 'net10.0' ">roslyn5.0</RoslynVersion>
+	<RoslynVersion Condition=" '$(TargetFramework)' == 'net11.0' ">roslyn5.9</RoslynVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+	<ProjectReference Include="../../src/Immediate.Validations.Analyzers/Immediate.Validations.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false">
+	  <SetTargetFramework>TargetFramework=$(RoslynVersion)</SetTargetFramework>
+	</ProjectReference>
+
+	<ProjectReference Include="../../src/Immediate.Validations.CodeFixes/Immediate.Validations.CodeFixes.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false">
+	  <SetTargetFramework>TargetFramework=$(RoslynVersion)</SetTargetFramework>
+	</ProjectReference>
+
+	<ProjectReference Include="../../src/Immediate.Validations.Generators/Immediate.Validations.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false">
+	  <SetTargetFramework>TargetFramework=$(RoslynVersion)</SetTargetFramework>
+	</ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/tests/Immediate.Validations.FunctionalTests/Resources/Validators.Designer.cs
+++ b/tests/Immediate.Validations.FunctionalTests/Resources/Validators.Designer.cs
@@ -19,7 +19,7 @@ namespace Immediate.Validations.FunctionalTests.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Validators {

--- a/tests/Immediate.Validations.Tests/Immediate.Validations.Tests.csproj
+++ b/tests/Immediate.Validations.Tests/Immediate.Validations.Tests.csproj
@@ -3,8 +3,10 @@
   <PropertyGroup>
 	<OutputType>Exe</OutputType>
 	<_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
-	<!-- Temporary fix for packaging bug -->
-	<NoWarn>$(NoWarn);NU1603</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
+	<Features>runtime-async=on</Features>
   </PropertyGroup>
 
   <ItemGroup Label="Usings">
@@ -44,20 +46,38 @@
 
   <ItemGroup>
 	<ProjectReference Include="../../src/Immediate.Validations.Shared/Immediate.Validations.Shared.csproj" />
-	<ProjectReference Include="../../src/Immediate.Validations.Analyzers/Immediate.Validations.Analyzers.csproj" />
-	<ProjectReference Include="../../src/Immediate.Validations.CodeFixes/Immediate.Validations.CodeFixes.csproj" />
-	<ProjectReference Include="../../src/Immediate.Validations.Generators/Immediate.Validations.Generators.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+	<RoslynVersion Condition=" '$(TargetFramework)' == 'net8.0' ">roslyn4.8</RoslynVersion>
+	<RoslynVersion Condition=" '$(TargetFramework)' == 'net10.0' ">roslyn5.0</RoslynVersion>
+	<RoslynVersion Condition=" '$(TargetFramework)' == 'net11.0' ">roslyn5.9</RoslynVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+	<ProjectReference Include="../../src/Immediate.Validations.Analyzers/Immediate.Validations.Analyzers.csproj" ReferenceOutputAssembly="false">
+	  <SetTargetFramework>TargetFramework=$(RoslynVersion)</SetTargetFramework>
+	</ProjectReference>
+	<Reference Include="../../src/Immediate.Validations.Analyzers/bin/$(Configuration)/$(RoslynVersion)/Immediate.Validations.Analyzers.dll" />
+
+	<ProjectReference Include="../../src/Immediate.Validations.CodeFixes/Immediate.Validations.CodeFixes.csproj" ReferenceOutputAssembly="false">
+	  <SetTargetFramework>TargetFramework=$(RoslynVersion)</SetTargetFramework>
+	</ProjectReference>
+	<Reference Include="../../src/Immediate.Validations.CodeFixes/bin/$(Configuration)/$(RoslynVersion)/Immediate.Validations.CodeFixes.dll" />
+
+	<ProjectReference Include="../../src/Immediate.Validations.Generators/Immediate.Validations.Generators.csproj" ReferenceOutputAssembly="false">
+	  <SetTargetFramework>TargetFramework=$(RoslynVersion)</SetTargetFramework>
+	</ProjectReference>
+	<Reference Include="../../src/Immediate.Validations.Generators/bin/$(Configuration)/$(RoslynVersion)/Immediate.Validations.Generators.dll" />
+  </ItemGroup>
+
+  <ItemGroup>
+	<Compile Include="../../src/Immediate.Validations.Analyzers/DiagnosticIds.cs" />
   </ItemGroup>
 
   <ItemGroup>
 	<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" PrivateAssets="all" GeneratePathProperty="true" />
-
-	<Reference Condition=" '$(TargetFramework)' != 'net10.0' "
-			   Include="$(PkgMicrosoft_CodeAnalysis_NetAnalyzers)\analyzers\dotnet\cs\Microsoft.CodeAnalysis.NetAnalyzers.dll" />
-	<Reference Condition=" '$(TargetFramework)' == 'net10.0' "
-			   Include="$(PkgMicrosoft_CodeAnalysis_NetAnalyzers)\analyzers\dotnet\Microsoft.CodeAnalysis.NetAnalyzers.dll" />
-
-	<Reference Include="$(PkgMicrosoft_CodeAnalysis_NetAnalyzers)\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll" />
+	<Reference Include="$(PkgMicrosoft_CodeAnalysis_NetAnalyzers)\analyzers\dotnet\cs\Microsoft.CodeAnalysis.NetAnalyzers.dll" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated package builds to support Roslyn 4.8, 5.0, and 5.9 across the supported .NET targets.
  * Removed .NET 9.0 from the supported target framework list.
  * Improved compatibility for analyzer, code-fix, and source-generator packages across supported compiler versions.

* **Packaging**
  * Added package validation against the 3.0.0 baseline.
  * Updated analyzer dependencies and package metadata for newer compiler environments.

* **Tests**
  * Updated functional and compatibility coverage for the supported .NET and Roslyn combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->